### PR TITLE
Use `justify-content: space-evenly` for menu

### DIFF
--- a/style.css
+++ b/style.css
@@ -10,9 +10,8 @@ body {
 /* Navigation menu */
 #menu {
     display: flex;
-    justify-content: center;
+    justify-content: space-evenly;
     align-items: flex-start;
-    gap: 35px;
     flex-wrap: nowrap;
     margin-bottom: 40px;
 }
@@ -216,8 +215,7 @@ put it in a div with this class. */
     }
 
     #menu {
-        gap: 0px;
-        
+        justify-content: space-between;
     }
 
     .menu-item {


### PR DESCRIPTION
I think this is a better choice technically when using `flex`, but if it's too late for us to make a major CSS change to the menu, that's fine. cc @jguer105-cool if she has any thoughts. 

Found it in [this video](https://www.youtube.com/watch?v=phWxA89Dy94).